### PR TITLE
Added tags field to Product form to avoid errors when adding products

### DIFF
--- a/app/config/admin/entities/product.yml
+++ b/app/config/admin/entities/product.yml
@@ -45,6 +45,7 @@ easy_admin:
                     - { property: 'imageFile', type: 'Vich\UploaderBundle\Form\Type\VichImageType' }
                     - features
                     - categories
+                    - tags
                     - enabled
                     - { property: 'description', type: 'Ivory\CKEditorBundle\Form\Type\CKEditorType' }
                     - createdAt


### PR DESCRIPTION
`tags` is mandatory for product entity. This PR avoids this error:

![add_product_error](https://cloud.githubusercontent.com/assets/73419/13728724/99f81e08-e921-11e5-9cb4-51534c67c511.png)
