### PR TITLE
Register WebServerBundle in AppKernel to run 'bin/console server:run'

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -28,6 +28,11 @@ class AppKernel extends Kernel
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
             $bundles[] = new Doctrine\Bundle\FixturesBundle\DoctrineFixturesBundle();
+
+            if (class_exists('Symfony\Bundle\WebServerBundle\WebServerBundle')) {
+                // for Symfony versions below 3.3 the bundle does not exist and is not needed
+                $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+            }
         }
 
         return $bundles;


### PR DESCRIPTION
As of Symfony 3.3 the web-server commands are separated into their own bundle, which makes the app not working like described in the README.md.

This is already mentioned in issue #45.