### PR TITLE
Loading class cache isn't needed for PHP >= 7.0 anymore

### DIFF
--- a/web/app.php
+++ b/web/app.php
@@ -19,7 +19,9 @@ $apcLoader->register(true);
 */
 
 $kernel = new AppKernel('prod', false);
-$kernel->loadClassCache();
+if (PHP_VERSION_ID < 70000) {
+    $kernel->loadClassCache();
+}
 //$kernel = new AppCache($kernel);
 
 // When using the HttpCache, you need to call the method in your front controller instead of relying on the configuration parameter

--- a/web/app_dev.php
+++ b/web/app_dev.php
@@ -25,7 +25,10 @@ $loader = require __DIR__.'/../app/autoload.php';
 Debug::enable();
 
 $kernel = new AppKernel('dev', true);
-$kernel->loadClassCache();
+if (PHP_VERSION_ID < 70000) {
+    $kernel->loadClassCache();
+}
+
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);
 $response->send();


### PR DESCRIPTION
The improvements in PHP 7 made the class cache superfluously, so that it
has been deprecated in the Symfony Standard stack (see
https://github.com/symfony/symfony-standard/pull/1030).

So I have merged those changes into this demo, too.