### PR TITLE
Removed database parameter line as it is no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ How to install this project
   1. `git clone https://github.com/javiereguiluz/easy-admin-demo`
   1. `cd easy-admin-demo`
   1. `composer install`
-  1. Edit `app/config/parameters.yml` and configure
-     credentials to acces a database for this demo.
   1. `php bin/console doctrine:database:create`
   1. `php bin/console doctrine:schema:create`
   1. `php bin/console doctrine:fixtures:load --append`


### PR DESCRIPTION
There is no longer an `app/config` folder and an `easyadmin.sqlite` database is used as a default.