### PR TITLE
Remove constant visibility for compat with php7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+    - 7.0
     - 7.1
 
 sudo: false

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -22,7 +22,7 @@ class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 
-    private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
+    const CONFIG_EXTS = '.{php,xml,yaml,yml}';
 
     public function __construct($environment, $debug)
     {


### PR DESCRIPTION
Currently, the project can't be booted with php7.0, while it should be as it's stated in [composer.json](https://github.com/javiereguiluz/easy-admin-demo/blob/master/composer.json#L23).

As seen in the PHP [official documentation](http://php.net/manual/en/language.oop5.constants.php) :
![image](https://user-images.githubusercontent.com/5771858/34916680-4b2694bc-f93c-11e7-9d6f-62a95abe6b62.png)

So if this PR is not accepted, the minimal required PHP version should be bumped to 7.1 in composer.json.

I'm not very comfortable with removing things for compatibility but IMO on this case, the visibility modifier does not bring something very important so it's ok.