### PR TITLE
Fix #73 Creating a new purchase leads to exception

### DIFF
--- a/src/DataFixtures/LoadPurchases.php
+++ b/src/DataFixtures/LoadPurchases.php
@@ -24,10 +24,7 @@ class LoadPurchases extends Fixture implements OrderedFixtureInterface
             $purchase->setCreatedAt(new \DateTime("now +$i seconds"));
             $purchase->setShipping(new \StdClass());
             $purchase->setDeliveryHour($this->getRandomHour());
-            $purchase->setBillingAddress(json_encode(array(
-                'line1' => '1234 Main Street',
-                'line2' => 'Big City, XX 23456',
-            )));
+            $purchase->setBillingAddress("1234 Main Street\nBig City, XX 23456");
             $purchase->setBuyer($this->getReference('user-'.($i % 20)));
 
             $this->addReference('purchase-'.$i, $purchase);

--- a/src/Entity/Purchase.php
+++ b/src/Entity/Purchase.php
@@ -77,9 +77,9 @@ class Purchase
      * The customer billing address.
      *
      * @var array
-     * @ORM\Column(type="json_array")
+     * @ORM\Column(type="text")
      */
-    protected $billingAddress = array();
+    protected $billingAddress;
 
     /**
      * The user who made the purchase.
@@ -113,7 +113,7 @@ class Purchase
     /**
      * Set the address where the customer want its billing.
      *
-     * @param array $billingAddress
+     * @param string $billingAddress
      */
     public function setBillingAddress($billingAddress)
     {
@@ -121,7 +121,7 @@ class Purchase
     }
 
     /**
-     * @return array
+     * @return string
      */
     public function getBillingAddress()
     {


### PR DESCRIPTION
Issue was caused by inability to convert array from Purchase::billingAddress to string, so that it can be shown in a textarea in the CMS. Simplest possible solution is to change the field type from json_array to text.